### PR TITLE
[ZEPPELIN-2850]

### DIFF
--- a/zeppelin-web/src/app/notebook/save-as/save-as.service.js
+++ b/zeppelin-web/src/app/notebook/save-as/save-as.service.js
@@ -38,7 +38,10 @@ function SaveAsService (browserDetectService) {
       }
       angular.element('body > iframe#SaveAsId').remove()
     } else {
-      content = 'data:image/svg;charset=utf-8,' + BOM + encodeURIComponent(content)
+      let binaryData = []
+      binaryData.push(content)
+      content = window.URL.createObjectURL(new Blob(binaryData))
+
       angular.element('body').append('<a id="SaveAsId"></a>')
       let saveAsElement = angular.element('body > a#SaveAsId')
       saveAsElement.attr('href', content)


### PR DESCRIPTION
### What is this PR for?
in save-as.service.js, if we use URI Data scheme, we could only contain 2MB data in chrome. using the createObjectURL and File API's blob feature, i managed to upgrade the capacity to about 900MB. plus this update is better in debugging too. if we exceed the 2MB limit in URI data scheme, the download just failed with no accurate console log originally, so it was kinda hard to know why this happens. But using this technique, if it exceeds the 900MB limit, the console log points directly about what the problem is. like this : Uncaught RangeError: Failed to construct 'Blob': Array length exceeds supported limit. 

https://github.com/apache/zeppelin/blob/master/zeppelin-web/src/app/notebook/save-as/save-as.service.js

### What type of PR is it?
Improvement

### Todos
* nothing more i guess

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2850

### How should this be tested?
open zeppelin using chrome. make a table by select, then download it by csv or tsv. the table should be BIG, like really big, (but not that big for companies, which is my case) to test. in the original version if the whole data exceeds 2MB, you could see that the download fails. but using my script, it doesn't fail until it reaches about 900MB~1GB, which is a tremendous improvement. 

### Screenshots (if appropriate)
i'll post it later if you really need it. but i'm pretty sure you guys know what i'm talking about :) 

### Questions:
* Does the licenses files need update? no (i guess)
* Is there breaking changes for older versions? no
* Does this needs documentation? maybe?
